### PR TITLE
add custom process_exception for insufficient capacity available

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,6 @@ After you have been invited, you can generate an API key by visiting the [Phonic
 
 Please set it to the environment variable `PHONIC_API_KEY`.
 
-```
-uv sync --extra dev
-uv run python sts.py
-```
-
 ## Installation
 ```
 pip install phonic-python

--- a/phonic/client.py
+++ b/phonic/client.py
@@ -162,6 +162,10 @@ class PhonicAsyncWebsocketClient:
                     await asyncio.sleep(15)
                     logger.debug("sender loop attempting reconnect")
                     await self._connect()
+                    if hasattr(self, "config_message"):
+                        await self._websocket.send(
+                            json.dumps(self.config_message)
+                        )  # resend config message
                     continue
                 else:
                     logger.error(f"Error in sender loop: {e}")
@@ -291,7 +295,7 @@ class PhonicSTSClient(PhonicAsyncWebsocketClient):
         if not self._is_running:
             raise RuntimeError("WebSocket connection not established")
 
-        config_message = {
+        self.config_message = {
             "type": "config",
             "input_format": input_format,
             "output_format": output_format,
@@ -300,7 +304,7 @@ class PhonicSTSClient(PhonicAsyncWebsocketClient):
             "welcome_message": welcome_message,
             "voice_id": voice_id,
         }
-        await self._websocket.send(json.dumps(config_message))
+        await self._websocket.send(json.dumps(self.config_message))
 
         async for message in self.start_bidirectional_stream():
             yield message

--- a/phonic/client.py
+++ b/phonic/client.py
@@ -76,7 +76,6 @@ class PhonicAsyncWebsocketClient:
         self._tasks: list[asyncio.Task] = []
 
     def _is_4004(self, exception: Exception) -> bool:
-        logger.debug(f"{exception=}")
         if isinstance(exception, ConnectionClosedError) and exception.code == 4004:
             return True
         else:
@@ -106,7 +105,7 @@ class PhonicAsyncWebsocketClient:
             self.uri,
             additional_headers={"Authorization": f"Bearer {self.api_key}"},
             max_size=5 * 1024 * 1024,
-            open_timeout=15,  # 4004 takes up to 15 seconds
+            open_timeout=20,  # 4004 takes up to 15 seconds
             process_exception=self._process_exception,
         )
         self._is_running = True

--- a/phonic/client.py
+++ b/phonic/client.py
@@ -99,6 +99,7 @@ class PhonicAsyncWebsocketClient:
             self.uri,
             additional_headers={"Authorization": f"Bearer {self.api_key}"},
             max_size=5 * 1024 * 1024,
+            open_timeout=None,  # 4004 takes up to 15 seconds
             process_exception=self._process_exception,
         )
         self._is_running = True

--- a/sts-stress-test.py
+++ b/sts-stress-test.py
@@ -61,4 +61,4 @@ if __name__ == "__main__":
     print("Audio streaming will begin automatically when connected.")
     print("Press Ctrl+C to exit")
     for i in range(10):
-        asyncio.run(main())
+        asyncio.create_task(main())

--- a/sts-stress-test.py
+++ b/sts-stress-test.py
@@ -3,7 +3,7 @@ import os
 
 from loguru import logger
 
-from phonic.audio_interface import ContinuousAudioInterface
+from phonic.audio_interface import PyaudioContinuousAudioInterface
 from phonic.client import PhonicSTSClient, get_voices
 
 
@@ -19,7 +19,9 @@ async def main():
 
     try:
         async with PhonicSTSClient(STS_URI, API_KEY) as client:
-            audio_streamer = ContinuousAudioInterface(client, sample_rate=SAMPLE_RATE)
+            audio_streamer = PyaudioContinuousAudioInterface(
+                client, sample_rate=SAMPLE_RATE
+            )
 
             sts_stream = client.sts(
                 input_format="pcm_44100",

--- a/sts-stress-test.py
+++ b/sts-stress-test.py
@@ -8,7 +8,7 @@ from phonic.client import PhonicSTSClient, get_voices
 
 
 async def main():
-    STS_URI = "wss://api.phonic.co/v1/sts/ws"
+    STS_URI = "wss://api.test.phonic.co/v1/sts/ws"
     API_KEY = os.environ["PHONIC_API_KEY"]
     SAMPLE_RATE = 44100
 

--- a/sts-stress-test.py
+++ b/sts-stress-test.py
@@ -1,0 +1,64 @@
+import asyncio
+import os
+
+from loguru import logger
+
+from phonic.audio_interface import ContinuousAudioInterface
+from phonic.client import PhonicSTSClient, get_voices
+
+
+async def main():
+    STS_URI = "wss://api.phonic.co/v1/sts/ws"
+    API_KEY = os.environ["PHONIC_API_KEY"]
+    SAMPLE_RATE = 44100
+
+    voices = get_voices(API_KEY)
+    voice_ids = [voice["id"] for voice in voices]
+    logger.info(f"Available voices: {voice_ids}")
+    voice_selected = "katherine"
+
+    try:
+        async with PhonicSTSClient(STS_URI, API_KEY) as client:
+            audio_streamer = ContinuousAudioInterface(client, sample_rate=SAMPLE_RATE)
+
+            sts_stream = client.sts(
+                input_format="pcm_44100",
+                output_format="pcm_44100",
+                system_prompt="You are a helpful voice assistant. Respond conversationally.",
+                # welcome_message="Hello! I'm your voice assistant. How can I help you today?",
+                voice_id=voice_selected,
+            )
+
+            await audio_streamer.start()
+
+            logger.info(f"Starting STS conversation with voice {voice_selected}...")
+            print("Starting conversation... (Ctrl+C to exit)")
+            print("Streaming all audio continuously to the server. Start talking!")
+
+            # Process messages from STS
+            async for message in sts_stream:
+                message_type = message.get("type")
+                if message_type == "audio_chunk":
+                    audio_streamer.add_audio_to_playback(message["audio"])
+                    if text := message.get("text"):
+                        logger.info(f"Assistant: {text}")
+                elif message_type == "input_text":
+                    logger.info(f"You: {message['text']}")
+
+    except KeyboardInterrupt:
+        logger.info("Conversation stopped by user")
+        if "audio_streamer" in locals():
+            audio_streamer.stop()
+    except Exception as e:
+        logger.error(f"Error in conversation: {e}")
+        if "audio_streamer" in locals():
+            audio_streamer.stop()
+        raise e
+
+
+if __name__ == "__main__":
+    print("Starting continuous Speech-to-Speech conversation...")
+    print("Audio streaming will begin automatically when connected.")
+    print("Press Ctrl+C to exit")
+    for i in range(10):
+        asyncio.run(main())


### PR DESCRIPTION
There is a chance that all of our GPU capacity is full at the moment a websocket tries to connect to our API. This PR adds some error handling to retry and display a message about insufficient capacity available.