### PR TITLE
get rid of 250ms twilio media payload buffer because phonic-api is now stronger than ever

### DIFF
--- a/phonic/twilio_interface.py
+++ b/phonic/twilio_interface.py
@@ -35,8 +35,6 @@ class TwilioInterface(ContinuousAudioInterface):
         # Twilio always uses mulaw, 8000 Hz 8-bit PCM
         self.sample_rate = 8000
         self.input_dtype = np.uint8
-        self.input_buffer: list[np.ndarray] = []
-        self.input_buffer_len = 0.0
 
         # Input / Output threads and loops
         self.main_loop = asyncio.get_event_loop()
@@ -70,20 +68,9 @@ class TwilioInterface(ContinuousAudioInterface):
                 audio_bytes = base64.b64decode(data["media"]["payload"])
                 audio_np = np.frombuffer(audio_bytes, dtype=self.input_dtype)
 
-                # Twilio chunks are too short (20ms);
-                # accumulate to >=250ms then send to Phonic API
-                self.input_buffer.append(audio_np)
-                self.input_buffer_len += len(audio_np) / self.sample_rate
-
-        if self.input_buffer_len >= 0.250:
-            concat_audio_np = np.concatenate(self.input_buffer)
-            self.input_buffer = []
-            self.input_buffer_len = 0.0
-
-            # Send to PhonicAsyncWebsocketClient
-            asyncio.run_coroutine_threadsafe(
-                self.client.send_audio(concat_audio_np), self.main_loop
-            )
+                asyncio.run_coroutine_threadsafe(
+                    self.client.send_audio(audio_np), self.main_loop
+                )
 
     def _start_input_stream(self):
         # unused, handled by Twilio


### PR DESCRIPTION
## Summary
Phonic API VAD detection should not depend on the size of the media payload (eg Twilio's media payload window is 20ms, the playground can be 100ms or 500ms or so). As such, there is no need to have an input buffer anymore.

## Test Plan
Tested the Twilio script and it works!