### PR TITLE
Downgrade websockets to 12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "scipy>=1.15.1",
     "sounddevice>=0.5.1",
     "typing-extensions>=4.12.2",
-    "websockets==15.0.0",
+    "websockets>=12,<13",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
```Because fal==1.7.6 depends on websockets>=12.0,<13 and phonic-python==0.1.5 depends on websockets==15.0.0, we can conclude that fal==1.7.6 and phonic-python==0.1.5 are incompatible.```
We decided to keep `fal` in `echo`, and to make `phonic-python` installable in `echo`, we need to downgrade `websockets`.