### PR TITLE
Update Tools to take in project info now that Tools are scoped under Projects, not Orgs [PHO-391]

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ webhook_tool = tools.create(
     description="Returns the next invoice of the given user",
     type="custom_webhook",
     execution_mode="sync",  # Only "sync" is supported for webhook tools
+    project="main",  # Optional, defaults to server default ("main")
     endpoint_method="POST",
     endpoint_url="https://myapp.com/webhooks/next-invoice",
     endpoint_headers={
@@ -311,6 +312,7 @@ websocket_tool = tools.create(
     description="Gets personalized product recommendations",
     type="custom_websocket",
     execution_mode="async",
+    project="main",  # Optional, defaults to server default ("main")
     tool_call_output_timeout_ms=5000,  # Optional, defaults to 15000
     parameters=[
         {
@@ -375,8 +377,11 @@ from phonic.client import Tools
 
 tools = Tools(api_key=API_KEY)
 
-# List all tools for the organization
+# List all tools for the default project ("main")
 tools_list = tools.list()
+
+# List tools for a specific project
+tools_list = tools.list(project="customer-support")
 ```
 
 #### Response Format
@@ -386,8 +391,14 @@ tools_list = tools.list()
   "tools": [
     {
       "id": "tool_12cf6e88-c254-4d3e-a149-ddf1bdd2254c",
+      "project": {
+        "id": "proj_fc86489d-fa2d-4921-8f14-7b95a926d481",
+        "name": "main"
+      },
       "name": "next_invoice",
       "description": "Returns the next invoice of the given user",
+      "type": "custom_webhook",
+      "execution_mode": "sync",
       "endpoint_url": "https://myapp.com/webhooks/next-invoice",
       "endpoint_method": "POST",
       "endpoint_headers": {
@@ -428,11 +439,14 @@ from phonic.client import Tools
 
 tools = Tools(api_key=API_KEY)
 
-# Get tool by ID
+# Get tool by ID (works across all projects)
 tool = tools.get("tool_12cf6e88-c254-4d3e-a149-ddf1bdd2254c")
 
-# Get tool by name
+# Get tool by name (uses default project)
 tool = tools.get("next_invoice")
+
+# Get tool by name in specific project
+tool = tools.get("next_invoice", project="customer-support")
 ```
 
 #### Response Format
@@ -441,8 +455,14 @@ tool = tools.get("next_invoice")
 {
   "tool": {
     "id": "tool_12cf6e88-c254-4d3e-a149-ddf1bdd2254c",
+    "project": {
+      "id": "proj_fc86489d-fa2d-4921-8f14-7b95a926d481",
+      "name": "main"
+    },
     "name": "next_invoice",
     "description": "Returns the next invoice of the given user",
+    "type": "custom_webhook",
+    "execution_mode": "sync",
     "endpoint_url": "https://myapp.com/webhooks/next-invoice",
     "endpoint_method": "POST",
     "endpoint_headers": {
@@ -482,7 +502,7 @@ from phonic.client import Tools
 
 tools = Tools(api_key=API_KEY)
 
-# Update webhook tool by name
+# Update webhook tool by name (uses default project)
 tools.update(
     "next_invoice",
     name="next_invoice_updated",
@@ -518,6 +538,13 @@ tools.update(
     ]
 )
 
+# Update tool by name in specific project
+tools.update(
+    "next_invoice",
+    project="customer-support",
+    description="Updated description for customer support project"
+)
+
 # For WebSocket tools, use tool_call_output_timeout_ms instead of endpoint fields
 tools.update(
     "get_product_recommendations",
@@ -535,11 +562,14 @@ from phonic.client import Tools
 
 tools = Tools(api_key=API_KEY)
 
-# Delete tool by ID
+# Delete tool by ID (works across all projects)
 tools.delete("tool_12cf6e88-c254-4d3e-a149-ddf1bdd2254c")
 
-# Delete tool by name
+# Delete tool by name (uses default project)
 tools.delete("next_invoice")
+
+# Delete tool by name in specific project
+tools.delete("next_invoice", project="customer-support")
 ```
 
 ## 🎤 Voices

--- a/src/phonic/client.py
+++ b/src/phonic/client.py
@@ -763,6 +763,7 @@ class Tools(PhonicHTTPClient):
         type: Literal["custom_webhook", "custom_websocket"],
         execution_mode: Literal["sync", "async"],
         *,
+        project: str = "main",
         endpoint_url: str | NotGiven = NOT_GIVEN,
         endpoint_method: Literal["POST"] | NotGiven = NOT_GIVEN,
         endpoint_timeout_ms: int | NotGiven = NOT_GIVEN,
@@ -774,7 +775,7 @@ class Tools(PhonicHTTPClient):
 
         Args:
             name: Required. The name of the tool. Must be snake_case (lowercase letters,
-                  numbers, and underscores only). Must be unique within the organization.
+                  numbers, and underscores only). Must be unique within the project.
             description: Required. A description of what the tool does.
             type: Required. The type of tool. Must be either "custom_webhook" (HTTP endpoint)
                   or "custom_websocket".
@@ -782,6 +783,7 @@ class Tools(PhonicHTTPClient):
                         - "sync" - The voice agent waits for the tool response before continuing
                         - "async" - The voice agent continues the conversation without waiting
                                    for the tool response (Only supported for custom_websocket tools)
+            project: Optional. The name of the project to create the tool in. Defaults to "main".
             endpoint_url: Required for custom_webhook tools. The URL that will be called when the tool is invoked.
             endpoint_method: Required for custom_webhook tools. Only "POST" is supported for now.
             endpoint_timeout_ms: Optional. Timeout in milliseconds for the endpoint call.
@@ -804,41 +806,49 @@ class Tools(PhonicHTTPClient):
         Returns:
             Dictionary containing the tool ID and name: {"id": "tool_...", "name": "..."}
         """
-        excluded = {"self", "excluded"}
+        excluded = {"self", "project", "excluded"}
         data = {
             k: v
             for k, v in locals().items()
             if k not in excluded and v is not NOT_GIVEN
         }
 
-        return self._post("/tools", data)
+        params = {"project": project}
+        return self._post("/tools", data, params)
 
-    def get(self, identifier: str) -> dict:
+    def get(self, identifier: str, *, project: str = "main") -> dict:
         """Get a tool by ID or name.
 
         Args:
             identifier: Tool ID (starting with "tool_" followed by UUID) or tool name
+            project: Optional. The name of the project containing the tool.
+                    Defaults to "main". Only used when looking up by name.
 
         Returns:
             Dictionary containing the tool details under the "tool" key
         """
-        return self._get(f"/tools/{identifier}")
+        params = {"project": project}
+        return self._get(f"/tools/{identifier}", params)
 
-    def delete(self, identifier: str) -> dict:
+    def delete(self, identifier: str, *, project: str = "main") -> dict:
         """Delete a tool by ID or name.
 
         Args:
             identifier: Tool ID (starting with "tool_" followed by UUID) or tool name
+            project: Optional. The name of the project containing the tool.
+                    Defaults to "main". Only used when deleting by name.
 
         Returns:
             Dictionary containing success status: {"success": true}
         """
-        return self._delete(f"/tools/{identifier}")
+        params = {"project": project}
+        return self._delete(f"/tools/{identifier}", params)
 
     def update(
         self,
         identifier: str,
         *,
+        project: str = "main",
         name: str | NotGiven = NOT_GIVEN,
         description: str | NotGiven = NOT_GIVEN,
         type: Literal["custom_webhook", "custom_websocket"] | NotGiven = NOT_GIVEN,
@@ -854,7 +864,9 @@ class Tools(PhonicHTTPClient):
 
         Args:
             identifier: Tool ID (starting with "tool_") or tool name
-            name: Tool name. Must be snake_case and unique within the organization.
+            project: Optional. The name of the project containing the tool.
+                    Defaults to "main". Only used when updating by name.
+            name: Tool name. Must be snake_case and unique within the project.
             description: Description of what the tool does.
             type: The type of tool. Must be either "custom_webhook" or "custom_websocket".
             endpoint_url: The URL that will be called when the tool is invoked (custom_webhook only).
@@ -871,22 +883,27 @@ class Tools(PhonicHTTPClient):
         Returns:
             Dictionary containing success status: {"success": true}
         """
-        excluded = {"self", "identifier", "excluded"}
+        excluded = {"self", "identifier", "project", "excluded"}
         data = {
             k: v
             for k, v in locals().items()
             if k not in excluded and v is not NOT_GIVEN
         }
 
-        return self._patch(f"/tools/{identifier}", data)
+        params = {"project": project}
+        return self._patch(f"/tools/{identifier}", data, params)
 
-    def list(self) -> dict:
-        """List all tools for the organization.
+    def list(self, *, project: str = "main") -> dict:
+        """List all tools for a project.
+
+        Args:
+            project: Optional. The name of the project to list tools from. Defaults to "main".
 
         Returns:
             Dictionary containing a list of tools with full details under the "tools" key
         """
-        return self._get("/tools")
+        params = {"project": project}
+        return self._get("/tools", params)
 
 
 class Agents(PhonicHTTPClient):

--- a/src/phonic/client.py
+++ b/src/phonic/client.py
@@ -763,7 +763,7 @@ class Tools(PhonicHTTPClient):
         type: Literal["custom_webhook", "custom_websocket"],
         execution_mode: Literal["sync", "async"],
         *,
-        project: str = "main",
+        project: str | NotGiven = NOT_GIVEN,
         endpoint_url: str | NotGiven = NOT_GIVEN,
         endpoint_method: Literal["POST"] | NotGiven = NOT_GIVEN,
         endpoint_timeout_ms: int | NotGiven = NOT_GIVEN,
@@ -783,7 +783,7 @@ class Tools(PhonicHTTPClient):
                         - "sync" - The voice agent waits for the tool response before continuing
                         - "async" - The voice agent continues the conversation without waiting
                                    for the tool response (Only supported for custom_websocket tools)
-            project: Optional. The name of the project to create the tool in. Defaults to "main".
+            project: Optional. The name of the project to create the tool in. Defaults to server default ("main").
             endpoint_url: Required for custom_webhook tools. The URL that will be called when the tool is invoked.
             endpoint_method: Required for custom_webhook tools. Only "POST" is supported for now.
             endpoint_timeout_ms: Optional. Timeout in milliseconds for the endpoint call.
@@ -813,42 +813,42 @@ class Tools(PhonicHTTPClient):
             if k not in excluded and v is not NOT_GIVEN
         }
 
-        params = {"project": project}
+        params = {} if project is NOT_GIVEN else {"project": project}
         return self._post("/tools", data, params)
 
-    def get(self, identifier: str, *, project: str = "main") -> dict:
+    def get(self, identifier: str, *, project: str | NotGiven = NOT_GIVEN) -> dict:
         """Get a tool by ID or name.
 
         Args:
             identifier: Tool ID (starting with "tool_" followed by UUID) or tool name
             project: Optional. The name of the project containing the tool.
-                    Defaults to "main". Only used when looking up by name.
+                    Defaults to server default ("main"). Only used when looking up by name.
 
         Returns:
             Dictionary containing the tool details under the "tool" key
         """
-        params = {"project": project}
+        params = {} if project is NOT_GIVEN else {"project": project}
         return self._get(f"/tools/{identifier}", params)
 
-    def delete(self, identifier: str, *, project: str = "main") -> dict:
+    def delete(self, identifier: str, *, project: str | NotGiven = NOT_GIVEN) -> dict:
         """Delete a tool by ID or name.
 
         Args:
             identifier: Tool ID (starting with "tool_" followed by UUID) or tool name
             project: Optional. The name of the project containing the tool.
-                    Defaults to "main". Only used when deleting by name.
+                    Defaults to server default ("main"). Only used when deleting by name.
 
         Returns:
             Dictionary containing success status: {"success": true}
         """
-        params = {"project": project}
+        params = {} if project is NOT_GIVEN else {"project": project}
         return self._delete(f"/tools/{identifier}", params)
 
     def update(
         self,
         identifier: str,
         *,
-        project: str = "main",
+        project: str | NotGiven = NOT_GIVEN,
         name: str | NotGiven = NOT_GIVEN,
         description: str | NotGiven = NOT_GIVEN,
         type: Literal["custom_webhook", "custom_websocket"] | NotGiven = NOT_GIVEN,
@@ -865,7 +865,7 @@ class Tools(PhonicHTTPClient):
         Args:
             identifier: Tool ID (starting with "tool_") or tool name
             project: Optional. The name of the project containing the tool.
-                    Defaults to "main". Only used when updating by name.
+                    Defaults to server default ("main"). Only used when updating by name.
             name: Tool name. Must be snake_case and unique within the project.
             description: Description of what the tool does.
             type: The type of tool. Must be either "custom_webhook" or "custom_websocket".
@@ -890,19 +890,19 @@ class Tools(PhonicHTTPClient):
             if k not in excluded and v is not NOT_GIVEN
         }
 
-        params = {"project": project}
+        params = {} if project is NOT_GIVEN else {"project": project}
         return self._patch(f"/tools/{identifier}", data, params)
 
-    def list(self, *, project: str = "main") -> dict:
+    def list(self, *, project: str | NotGiven = NOT_GIVEN) -> dict:
         """List all tools for a project.
 
         Args:
-            project: Optional. The name of the project to list tools from. Defaults to "main".
+            project: Optional. The name of the project to list tools from. Defaults to server default ("main").
 
         Returns:
             Dictionary containing a list of tools with full details under the "tools" key
         """
-        params = {"project": project}
+        params = {} if project is NOT_GIVEN else {"project": project}
         return self._get("/tools", params)
 
 


### PR DESCRIPTION
- Added project parameter to all Tools methods with NOT_GIVEN default - lets server handle project defaults instead of hardcoding "main"
- Updated API calls to only send project query parameter when explicitly specified, following existing SDK patterns