### PR TITLE
Make the Config Payload default to OMIT

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,1 +1,2 @@
 # Specify files that shouldn't be modified by Fern
+src/phonic/types/config_payload.py

--- a/src/phonic/conversations/socket_client.py
+++ b/src/phonic/conversations/socket_client.py
@@ -8,8 +8,12 @@ import websockets
 import websockets.sync.connection as websockets_sync_connection
 from ..core.events import EventEmitterMixin, EventType
 from ..core.pydantic_utilities import parse_obj_as
-from ..types.assistant_chose_not_to_respond_payload import AssistantChoseNotToRespondPayload
-from ..types.assistant_ended_conversation_payload import AssistantEndedConversationPayload
+from ..types.assistant_chose_not_to_respond_payload import (
+    AssistantChoseNotToRespondPayload,
+)
+from ..types.assistant_ended_conversation_payload import (
+    AssistantEndedConversationPayload,
+)
 from ..types.audio_chunk_payload import AudioChunkPayload
 from ..types.audio_chunk_response_payload import AudioChunkResponsePayload
 from ..types.audio_finished_payload import AudioFinishedPayload
@@ -100,7 +104,9 @@ class AsyncConversationsSocketClient(EventEmitterMixin):
         """
         await self._send_model(message)
 
-    async def send_update_system_prompt(self, message: UpdateSystemPromptPayload) -> None:
+    async def send_update_system_prompt(
+        self, message: UpdateSystemPromptPayload
+    ) -> None:
         """
         Send a message to the websocket connection.
         The message will be sent as a UpdateSystemPromptPayload.

--- a/src/phonic/types/config_payload.py
+++ b/src/phonic/types/config_payload.py
@@ -7,110 +7,118 @@ from ..core.pydantic_utilities import IS_PYDANTIC_V2, UniversalBaseModel
 from .config_payload_input_format import ConfigPayloadInputFormat
 from .config_payload_output_format import ConfigPayloadOutputFormat
 
+OMIT = typing.cast(typing.Any, ...)
+
 
 class ConfigPayload(UniversalBaseModel):
     type: typing.Literal["config"] = "config"
-    agent: typing.Optional[str] = pydantic.Field(default=None)
+    agent: typing.Optional[str] = pydantic.Field(default=OMIT)
     """
     Agent name to use for conversation
     """
 
-    project: typing.Optional[str] = pydantic.Field(default=None)
+    project: typing.Optional[str] = pydantic.Field(default=OMIT)
     """
     Project name
     """
 
-    model: typing.Optional[typing.Literal["merritt"]] = pydantic.Field(default=None)
+    model: typing.Optional[typing.Literal["merritt"]] = pydantic.Field(default=OMIT)
     """
     STS model to use
     """
 
-    system_prompt: typing.Optional[str] = pydantic.Field(default=None)
+    system_prompt: typing.Optional[str] = pydantic.Field(default=OMIT)
     """
     System prompt for AI assistant
     """
 
-    audio_speed: typing.Optional[float] = pydantic.Field(default=None)
+    audio_speed: typing.Optional[float] = pydantic.Field(default=OMIT)
     """
     Audio playback speed
     """
 
-    welcome_message: typing.Optional[str] = pydantic.Field(default=None)
+    welcome_message: typing.Optional[str] = pydantic.Field(default=OMIT)
     """
     Message to play when conversation starts
     """
 
-    voice_id: typing.Optional[str] = pydantic.Field(default=None)
+    voice_id: typing.Optional[str] = pydantic.Field(default=OMIT)
     """
     Voice ID to use for speech synthesis
     """
 
-    input_format: typing.Optional[ConfigPayloadInputFormat] = pydantic.Field(default=None)
+    input_format: typing.Optional[ConfigPayloadInputFormat] = pydantic.Field(
+        default=OMIT
+    )
     """
     Audio input format
     """
 
-    output_format: typing.Optional[ConfigPayloadOutputFormat] = pydantic.Field(default=None)
+    output_format: typing.Optional[ConfigPayloadOutputFormat] = pydantic.Field(
+        default=OMIT
+    )
     """
     Audio output format
     """
 
-    vad_prebuffer_duration_ms: typing.Optional[float] = pydantic.Field(default=None)
+    vad_prebuffer_duration_ms: typing.Optional[float] = pydantic.Field(default=OMIT)
     """
     Voice activity detection prebuffer duration
     """
 
-    vad_min_speech_duration_ms: typing.Optional[float] = pydantic.Field(default=None)
+    vad_min_speech_duration_ms: typing.Optional[float] = pydantic.Field(default=OMIT)
     """
     Minimum speech duration for VAD
     """
 
-    vad_min_silence_duration_ms: typing.Optional[float] = pydantic.Field(default=None)
+    vad_min_silence_duration_ms: typing.Optional[float] = pydantic.Field(default=OMIT)
     """
     Minimum silence duration for VAD
     """
 
-    vad_threshold: typing.Optional[float] = pydantic.Field(default=None)
+    vad_threshold: typing.Optional[float] = pydantic.Field(default=OMIT)
     """
     Voice activity detection threshold
     """
 
-    enable_documents_rag: typing.Optional[bool] = pydantic.Field(default=None)
+    enable_documents_rag: typing.Optional[bool] = pydantic.Field(default=OMIT)
     """
     Enable document RAG
     """
 
-    enable_transcripts_rag: typing.Optional[bool] = pydantic.Field(default=None)
+    enable_transcripts_rag: typing.Optional[bool] = pydantic.Field(default=OMIT)
     """
     Enable transcript RAG
     """
 
-    no_input_poke_sec: typing.Optional[float] = pydantic.Field(default=None)
+    no_input_poke_sec: typing.Optional[float] = pydantic.Field(default=OMIT)
     """
     Seconds of silence before poke message
     """
 
-    no_input_poke_text: typing.Optional[str] = pydantic.Field(default=None)
+    no_input_poke_text: typing.Optional[str] = pydantic.Field(default=OMIT)
     """
     Poke message text
     """
 
-    no_input_end_conversation_sec: typing.Optional[float] = pydantic.Field(default=None)
+    no_input_end_conversation_sec: typing.Optional[float] = pydantic.Field(default=OMIT)
     """
     Seconds of silence before ending conversation
     """
 
-    boosted_keywords: typing.Optional[typing.List[str]] = pydantic.Field(default=None)
+    boosted_keywords: typing.Optional[typing.List[str]] = pydantic.Field(default=OMIT)
     """
     Keywords to boost in speech recognition
     """
 
-    tools: typing.Optional[typing.List[str]] = pydantic.Field(default=None)
+    tools: typing.Optional[typing.List[str]] = pydantic.Field(default=OMIT)
     """
     Tools available to the assistant
     """
 
-    template_variables: typing.Optional[typing.Dict[str, str]] = pydantic.Field(default=None)
+    template_variables: typing.Optional[typing.Dict[str, str]] = pydantic.Field(
+        default=OMIT
+    )
     """
     Template variables for system prompt and welcome message
     """

--- a/src/phonic/types/config_payload.py
+++ b/src/phonic/types/config_payload.py
@@ -124,7 +124,9 @@ class ConfigPayload(UniversalBaseModel):
     """
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
+            extra="allow", frozen=True
+        )  # type: ignore # Pydantic v2
     else:
 
         class Config:


### PR DESCRIPTION
For fields not entered into the Config for the STS websocket, we would like to default to OMIT, and have that not be sent via the STS websocket. 