### PR TITLE
1.3 Phonic Python publish action

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -8,3 +8,4 @@ src/phonic/conversations/reconnectable_socket_client.py
 .fern/replay.lock
 .fern/replay.yml
 .gitattributes
+.github/workflows/publish.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,63 @@
+name: Publish to PyPI
+
+# Publishes the package to PyPI when a PR is merged into main (i.e. when the SDK PR that
+# fern-config opened gets reviewed and merged). The version is whatever is in pyproject.toml,
+# which fern-config bakes in when it opens the PR.
+#
+# Mirrors the poetry publish job in the Fern-generated ci.yml (same command, same secrets),
+# but triggers on merge to main instead of on a git tag.
+#
+# Kept in .fernignore so Fern's regeneration doesn't remove it.
+#
+# Requires repo secrets: PYPI_USERNAME, PYPI_PASSWORD (already used by ci.yml's tag publish).
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: publish-pypi
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Bootstrap poetry
+        run: curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
+
+      - name: Read package version
+        id: v
+        run: echo "version=$(poetry version -s)" >> "$GITHUB_OUTPUT"
+
+      # Don't fail on unrelated merges to main — only publish a version that isn't live yet.
+      - name: Check if already published
+        id: check
+        run: |
+          if curl -fsSL "https://pypi.org/pypi/phonic/${{ steps.v.outputs.version }}/json" >/dev/null 2>&1; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "phonic ${{ steps.v.outputs.version }} already on PyPI — skipping."
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dependencies
+        if: steps.check.outputs.publish == 'true'
+        run: poetry install
+
+      - name: Publish to PyPI
+        if: steps.check.outputs.publish == 'true'
+        env:
+          PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          poetry config repositories.remote https://upload.pypi.org/legacy/
+          poetry --no-interaction -v publish --build --repository remote --username "$PYPI_USERNAME" --password "$PYPI_PASSWORD"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Publishing uses production PyPI credentials on every main push; the PyPI version check limits duplicate uploads but the job does not wait on compile/test from ci.yml.
> 
> **Overview**
> Adds **automatic PyPI publishing on merges to `main`**, aimed at Fern-generated SDK PRs whose version is already set in `pyproject.toml`.
> 
> A new workflow **`.github/workflows/publish.yml`** runs on every push to `main`, reads the Poetry version, **skips publish if that version already exists on PyPI**, otherwise runs the same `poetry publish` flow as the tag-based job in `ci.yml` (same secrets). **`publish-pypi` concurrency** avoids overlapping publishes. The workflow path is listed in **`.fernignore`** so Fern regeneration does not remove it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b49933f0de43d9e6a5c63819f13ddc03effc17d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Automated package publishing workflow enabled for streamlined releases to PyPI when changes are merged to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->