### PR TITLE
Make publish.yml the sole publisher (remove tag-triggered publish from ci.yml)

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -8,4 +8,5 @@ src/phonic/conversations/reconnectable_socket_client.py
 .fern/replay.lock
 .fern/replay.yml
 .gitattributes
+.github/workflows/ci.yml
 .github/workflows/publish.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,27 +39,3 @@ jobs:
 
       - name: Test
         run: poetry run pytest -rP -n auto .
-
-  publish:
-    needs: [compile, test]
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-      - name: Set up python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
-      - name: Bootstrap poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
-      - name: Install dependencies
-        run: poetry install
-      - name: Publish to pypi
-        run: |
-          poetry config repositories.remote https://upload.pypi.org/legacy/
-          poetry --no-interaction -v publish --build --repository remote --username "$PYPI_USERNAME" --password "$PYPI_PASSWORD"
-        env:
-          PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
## Problem

phonic-python had **two PyPI publishers competing**, which is why GitHub releases/tags froze at `v0.32.10` while PyPI marched on to `0.32.21`:

- **`ci.yml`** (Fern-generated) had a `publish` job gated on `contains(github.ref, 'refs/tags/')`. Fern pushes a **moving `fern-generation-base--fernapi--fern-python-sdk` tag** on every generation; that tag matched the guard and published the raw Fern output to PyPI — burning the version *before* the "SDK regeneration" PR was ever merged.
- **`publish.yml`** (on merge to main) is meant to publish **and** create the `vX.Y.Z` GitHub release/tag. But its "already published" guard then saw the version already live on PyPI, set `publish=false`, and skipped everything — including the release/tag creation. (Confirmed in run #163: `phonic 0.32.20 already on PyPI — skipping.`)

## Fix

Match **phonic-node**, whose `ci.yml` only compiles + tests:

- Remove the `publish` job from `ci.yml` → `publish.yml` becomes the single publisher and creates the release/tag on every merge to main.
- Add `.github/workflows/ci.yml` to `.fernignore` so Fern's next regeneration doesn't restore the job. (node doesn't need this because its JS generator doesn't emit a publish job; the Python generator does.)

## Relationship to #164

This **combines and supersedes #164** (Qiong's `qiong/fix-fern-tag-publish-bump-0.32.21`). Same net workflow change, but rebased clean onto current `main` so it doesn't:
- regress `.fern/metadata.json` (sdkVersion 0.32.21 → 0.32.20) or `.fern/replay.lock`, and
- carry a now-redundant 0.32.20 → 0.32.21 version bump (main is already at 0.32.21).

Qiong's root-cause investigation (the moving `fern-generation-base--*` tag) is credited via `Co-Authored-By`.

## Not included

This does not backfill the missing `v0.32.11`–`v0.32.21` GitHub releases/tags. Can be done separately with `gh release create` if we want the release history to match PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/CD workflow-only change; no runtime SDK code or auth logic touched.
> 
> **Overview**
> **Removes the tag-gated `publish` job from `ci.yml`** so CI only compiles and tests, aligning with phonic-node and stopping Fern’s moving generation tag from publishing to PyPI before merge.
> 
> **Adds `.github/workflows/ci.yml` to `.fernignore`** so Fern regenerations won’t reintroduce that publish job. **`publish.yml` on merge to `main`** remains the only path that publishes and creates GitHub releases/tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68613aba7ce101eabfb330d51448f24bba4920aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project automation settings to exclude the continuous integration workflow from automated modifications.
  * Removed the automated package publishing step from the CI workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->