### PR TITLE
Bump to 0.32.26 (publish sip_outbound_call wiring)

### DIFF
--- a/.fern/metadata.json
+++ b/.fern/metadata.json
@@ -11,5 +11,5 @@
     }
   },
   "originGitCommit": "76fb926783aeb267ae26f2984dd544419fb1331d",
-  "sdkVersion": "0.32.25"
+  "sdkVersion": "0.32.26"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "phonic"
-version = "0.32.25"
+version = "0.32.26"
 description = ""
 readme = "README.md"
 authors = []


### PR DESCRIPTION
#170 published 0.32.25 with the `sip` **type** but not the wiring; #171 added the wiring to `main` without bumping the version, so PyPI 0.32.25 lacks it and PyPI won't accept a re-publish of the same version.

This bumps `[tool.poetry] version` → **0.32.26** so `publish.yml` (fires on push to `main`) releases current `main` HEAD — types **and** wiring. After merge, `sip_outbound_call(sip=...)` works from 0.32.26 on.

Verified: published 0.32.25 sdist has `conversations_sip_outbound_call_request_sip.py` (type) but `grep` for the wiring in `raw_client.py` returns 0; `main` HEAD has it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime or API code changes in the diff—only version metadata for publishing.
> 
> **Overview**
> Bumps the published package version from **0.32.25** to **0.32.26** in `pyproject.toml` and `.fern/metadata.json` so CI can ship a new PyPI release.
> 
> This is a **release-only** change: `main` already includes `sip_outbound_call` client wiring from a prior merge, but **0.32.25** on PyPI only had the SIP request types. Re-publishing the same version is not allowed, so **0.32.26** is the first installable build where `client.conversations.sip_outbound_call(...)` matches the generated types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b165669f42780d7a06a65fdb1041bf978567010. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project version to 0.32.26.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->